### PR TITLE
Fixed overlapping title text by manually fixing line height in tagline

### DIFF
--- a/docs/src/app/Home.js
+++ b/docs/src/app/Home.js
@@ -36,6 +36,7 @@ class HomePage extends Component {
         margin: '16px auto 16px auto',
         textAlign: 'center',
         maxWidth: 900,
+        lineHeight: '56px',
       },
       label: {
         color: lightBaseTheme.palette.primary1Color,
@@ -117,7 +118,7 @@ class HomePage extends Component {
         contentStyle={styles.content}
         contentType="p"
         className="home-purpose"
-       >      
+       >
         <b>You can create apps for the Internet of Things with MIT App Inventor!</b>
 	      <br /><br />
         MIT App Inventor lets people around the world build mobile apps that can make a difference in their


### PR DESCRIPTION

<img width="768" alt="screen shot 2017-05-30 at 11 03 55 am" src="https://cloud.githubusercontent.com/assets/2035149/26590057/a730a816-4527-11e7-9d58-32ae853a1be4.png">
