### PR TITLE
Fix erroneous URL for Setup How To

### DIFF
--- a/docs/src/app/HowTos.js
+++ b/docs/src/app/HowTos.js
@@ -23,7 +23,7 @@ const howtosList = [
     title: 'How to: Set up the Arduino Development Environment',
     author: 'MIT App Inventor Project',
     img: 'assets/howtos/arduino_logo.png',
-    link: 'assets/howtos/MIT_App_Inventor_IoT_Setup.pdf',
+    link: 'assets/tutorials/MIT_App_Inventor_IoT_Setup.pdf',
   }, {
     title: 'Bluetooth Low Energy Basic Connection',
     author: 'MIT App Inventor Project',


### PR DESCRIPTION
One of the howtos is technically also a tutorial and its PDF lives under tutorials. This commit fixes the link which otherwise results in a 404.