### PR TITLE
Fix console errors from buttons

### DIFF
--- a/docs/src/app/Home.js
+++ b/docs/src/app/Home.js
@@ -140,13 +140,13 @@ class HomePage extends Component {
           <center>
             <RaisedButton
               label="Learn more about IoT" href="#LearnMore"
-              primary="true"
+              primary={true}
             />
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             <RaisedButton
               label="Learn more about MIT App Inventor"
               href="http://appinventor.mit.edu" target="_blank"
-              primary="true"
+              primary={true}
             />
           </center>
         </span>

--- a/docs/src/app/Home.js
+++ b/docs/src/app/Home.js
@@ -121,7 +121,7 @@ class HomePage extends Component {
         style={styles.root}
         useContent={true}
         contentStyle={styles.content}
-        contentType="p"
+        contentType="div"
         className="home-purpose"
       >
         <h3>Make apps for the Internet of Things with MIT App Inventor!</h3>

--- a/docs/src/app/LearnMorePage.js
+++ b/docs/src/app/LearnMorePage.js
@@ -51,7 +51,7 @@ class LearnMorePage extends Component {
         style={styles.root}
         useContent={true}
         contentStyle={styles.content}
-        contentType="p"
+        contentType="div"
         className="home-purpose"
       >
         <h3>Bring computing off the screen and into the world of everyday things!</h3>

--- a/docs/src/app/LearnMorePage.js
+++ b/docs/src/app/LearnMorePage.js
@@ -76,7 +76,7 @@ class LearnMorePage extends Component {
           <div style={styles.floatLeft}>
             <RaisedButton
               label="Get started!" href="#/getstarted/intro"
-              primary="true"
+              primary={true}
             /></div>
           <div style={styles.floatRight}>
             <RaisedButton


### PR DESCRIPTION
Noticed current implementation of page buttons were throwing errors in the console, from both incorrect parameter typing and content nesting. This fixes both, reducing to exactly one error (from the youtube embedded player)

**Please check carefully, as it changed the base type of the home page's content from `p` to `div`.**

(p is only for inline content, according to specs, so div is necessary for block content like buttons and other divs)