### PR TITLE
Many grammatical and phrasing fixes.

### DIFF
--- a/docs/src/app/pages/BluetoothLEIntro.md
+++ b/docs/src/app/pages/BluetoothLEIntro.md
@@ -19,17 +19,17 @@ Bluetooth Low Energy, also referred to as Bluetooth LE or simply BLE, is a new p
 
 ![get BluetoothLE1 AdvertiserNames ](blocks/BluetoothLE.AdvertiserNames_getter.svg)
 
-+ <a name="BatteryValue"></a>`BatteryValue` – Return the battery level.
++ <a name="BatteryValue"></a>`BatteryValue` – Returns the battery level.
 
 
 ![get BluetoothLE1 BatteryValue ](blocks/BluetoothLE.BatteryValue_getter.svg)
 
-+ <a name="ConnectedDeviceRssi"></a>`ConnectedDeviceRssi` – Return the RSSI (Received Signal Strength Indicator) of connected device.
++ <a name="ConnectedDeviceRssi"></a>`ConnectedDeviceRssi` – Returns the RSSI (Received Signal Strength Indicator) of connected device.
 
 
 ![get BluetoothLE1 ConnectedDeviceRssi ](blocks/BluetoothLE.ConnectedDeviceRssi_getter.svg)
 
-+ <a name="DeviceList"></a>`DeviceList` – Return a sorted list of BluetoothLE devices as a String.
++ <a name="DeviceList"></a>`DeviceList` – Returns a sorted list of BluetoothLE devices as a String.
 
 
 ![get BluetoothLE1 DeviceList ](blocks/BluetoothLE.DeviceList_getter.svg)
@@ -39,12 +39,12 @@ Bluetooth Low Energy, also referred to as Bluetooth LE or simply BLE, is a new p
 
 ![get BluetoothLE1 IsDeviceAdvertising ](blocks/BluetoothLE.IsDeviceAdvertising_getter.svg)
 
-+ <a name="IsDeviceConnected"></a>`IsDeviceConnected` – Return true if a BluetoothLE device is connected; Otherwise, return false.
++ <a name="IsDeviceConnected"></a>`IsDeviceConnected` – Returns true if a BluetoothLE device is connected; Otherwise, returns false.
 
 
 ![get BluetoothLE1 IsDeviceConnected ](blocks/BluetoothLE.IsDeviceConnected_getter.svg)
 
-+ <a name="TxPower"></a>`TxPower` – Return the Tx power.
++ <a name="TxPower"></a>`TxPower` – Returns the Tx power.
 
 
 ![get BluetoothLE1 TxPower ](blocks/BluetoothLE.TxPower_getter.svg)
@@ -63,79 +63,79 @@ Bluetooth Low Energy, also referred to as Bluetooth LE or simply BLE, is a new p
 
 ![call BluetoothLE1 AdvertiserServiceUuidsdeviceAddress](blocks/BluetoothLE.AdvertiserServiceUuids.svg)
 
-+ <a name="CharacteristicByIndex"></a>`CharacteristicByIndex` – Return Unique ID of selected characteristic with index. Index specified by list of supported characteristics for a connected device, starting from 1.
++ <a name="CharacteristicByIndex"></a>`CharacteristicByIndex` – Returns Unique ID of selected characteristic with index. Index specified by list of supported characteristics for a connected device, starting from 1.
 
 ![call BluetoothLE1 CharacteristicByIndexindex](blocks/BluetoothLE.CharacteristicByIndex.svg)
 
-+ <a name="Connect"></a>`Connect` – Connect to a BluetoothLE device with index. Index specifies the position in BluetoothLE device list, starting from 1.
++ <a name="Connect"></a>`Connect` – Connects to a BluetoothLE device with index. Index specifies the position in BluetoothLE device list, starting from 1.
 
 ![call BluetoothLE1 Connectindex](blocks/BluetoothLE.Connect.svg)
 
-+ <a name="ConnectWithAddress"></a>`ConnectWithAddress` – Connect to BluetoothLE device with address. Address specifies bluetooth address of the BluetoothLE device.
++ <a name="ConnectWithAddress"></a>`ConnectWithAddress` – Connects to BluetoothLE device with address. Address specifies bluetooth address of the BluetoothLE device.
 
 ![call BluetoothLE1 ConnectWithAddressaddress](blocks/BluetoothLE.ConnectWithAddress.svg)
 
-+ <a name="Disconnect"></a>`Disconnect` – Disconnect from the currently connected BluetoothLE device if a device is connected.
++ <a name="Disconnect"></a>`Disconnect` – Disconnects from the currently connected BluetoothLE device if a device is connected.
 
 ![call BluetoothLE1 Disconnect](blocks/BluetoothLE.Disconnect.svg)
 
-+ <a name="DisconnectWithAddress"></a>`DisconnectWithAddress` – Disconnect from connected BluetoothLE device with address. Address specifies bluetooth address of the BluetoothLE device.
++ <a name="DisconnectWithAddress"></a>`DisconnectWithAddress` – Disconnects from connected BluetoothLE device with address. Address specifies bluetooth address of the BluetoothLE device.
 
 ![call BluetoothLE1 DisconnectWithAddressaddress](blocks/BluetoothLE.DisconnectWithAddress.svg)
 
-+ <a name="FoundDeviceAddress"></a>`FoundDeviceAddress` – Get the address of found device with index. Index specifies the position in BluetoothLE device list, starting from 1.
++ <a name="FoundDeviceAddress"></a>`FoundDeviceAddress` – Gets the address of found device with index. Index specifies the position in BluetoothLE device list, starting from 1.
 
 ![call BluetoothLE1 FoundDeviceAddressindex](blocks/BluetoothLE.FoundDeviceAddress.svg)
 
-+ <a name="FoundDeviceName"></a>`FoundDeviceName` – Get the name of found device with index. Index specifies the position in BluetoothLE device list, starting from 1.
++ <a name="FoundDeviceName"></a>`FoundDeviceName` – Gets the name of found device with index. Index specifies the position in BluetoothLE device list, starting from 1.
 
 ![call BluetoothLE1 FoundDeviceNameindex](blocks/BluetoothLE.FoundDeviceName.svg)
 
-+ <a name="FoundDeviceRssi"></a>`FoundDeviceRssi` – Get the RSSI (Received Signal Strength Indicator) of found device with index. Index specifies the position in BluetoothLE device list, starting from 1.
++ <a name="FoundDeviceRssi"></a>`FoundDeviceRssi` – Gets the RSSI (Received Signal Strength Indicator) of found device with index. Index specifies the position in BluetoothLE device list, starting from 1.
 
 ![call BluetoothLE1 FoundDeviceRssiindex](blocks/BluetoothLE.FoundDeviceRssi.svg)
 
-+ <a name="GetCharacteristicsForService"></a>`GetCharacteristicsForService` – Return list of supported characteristics for the given service. The list will contain (UUID, name) pairs for each characteristic provided by the given service UUID.
++ <a name="GetCharacteristicsForService"></a>`GetCharacteristicsForService` – Returns list of supported characteristics for the given service. The list will contain (UUID, name) pairs for each characteristic provided by the given service UUID.
 
 ![call BluetoothLE1 GetCharacteristicsForServiceserviceUuid](blocks/BluetoothLE.GetCharacteristicsForService.svg)
 
-+ <a name="ReadBytes"></a>`ReadBytes` – Read one or more 8-bit integer values from a connected BluetoothLE device. Service Unique ID and Characteristic Unique ID are required.
++ <a name="ReadBytes"></a>`ReadBytes` – Reads one or more 8-bit integer values from a connected BluetoothLE device. Service Unique ID and Characteristic Unique ID are required.
 
 ![call BluetoothLE1 ReadBytesserviceUuidcharacteristicUuidsigned](blocks/BluetoothLE.ReadBytes.svg)
 
-+ <a name="ReadFloats"></a>`ReadFloats` – Read one or more floating point values from a connected Bluetooth device.
++ <a name="ReadFloats"></a>`ReadFloats` – Reads one or more floating point values from a connected Bluetooth device.
 
 ![call BluetoothLE1 ReadFloatsserviceUuidcharacteristicUuidshortFloat](blocks/BluetoothLE.ReadFloats.svg)
 
-+ <a name="ReadIntegers"></a>`ReadIntegers` – Read one or more 32-bit integer values from a connected BluetoothLE device.
++ <a name="ReadIntegers"></a>`ReadIntegers` – Reads one or more 32-bit integer values from a connected BluetoothLE device.
 
 ![call BluetoothLE1 ReadIntegersserviceUuidcharacteristicUuidsigned](blocks/BluetoothLE.ReadIntegers.svg)
 
-+ <a name="ReadShorts"></a>`ReadShorts` – Read one or more 16-bit integer values from a connected BluetoothLE device. Service Unique ID and Characteristic Unique ID are required.
++ <a name="ReadShorts"></a>`ReadShorts` – Reads one or more 16-bit integer values from a connected BluetoothLE device. Service Unique ID and Characteristic Unique ID are required.
 
 ![call BluetoothLE1 ReadShortsservice_uuidcharacteristic_uuidsigned](blocks/BluetoothLE.ReadShorts.svg)
 
-+ <a name="ReadStrings"></a>`ReadStrings` – Read one or more strings from a connected Bluetooth device.
++ <a name="ReadStrings"></a>`ReadStrings` – Reads one or more strings from a connected Bluetooth device.
 
 ![call BluetoothLE1 ReadStringsserviceUuidcharacteristicUuidutf16](blocks/BluetoothLE.ReadStrings.svg)
 
-+ <a name="RegisterForBytes"></a>`RegisterForBytes` – Register to receive updates when one or more 16-bit integer values from a connected BluetoothLE change. Service Unique ID and Characteristic Unique ID are required.
++ <a name="RegisterForBytes"></a>`RegisterForBytes` – Registers to receive updates when one or more 16-bit integer values from a connected BluetoothLE change. Service Unique ID and Characteristic Unique ID are required.
 
 ![call BluetoothLE1 RegisterForBytesserviceUuidcharacteristicUuidsigned](blocks/BluetoothLE.RegisterForBytes.svg)
 
-+ <a name="RegisterForFloats"></a>`RegisterForFloats` – Register to receive updates when one or more floating point values from a connected Bluetooth device change.
++ <a name="RegisterForFloats"></a>`RegisterForFloats` – Registers to receive updates when one or more floating point values from a connected Bluetooth device change.
 
 ![call BluetoothLE1 RegisterForFloatsserviceUuidcharacteristicUuidshortFloat](blocks/BluetoothLE.RegisterForFloats.svg)
 
-+ <a name="RegisterForIntegers"></a>`RegisterForIntegers` – Register to receive updates when one or more 32-bit integer values from a connected Bluetooth device change.
++ <a name="RegisterForIntegers"></a>`RegisterForIntegers` – Registers to receive updates when one or more 32-bit integer values from a connected Bluetooth device change.
 
 ![call BluetoothLE1 RegisterForIntegersserviceUuidcharacteristicUuidsigned](blocks/BluetoothLE.RegisterForIntegers.svg)
 
-+ <a name="RegisterForShorts"></a>`RegisterForShorts` – Register to receive updates when one or more 16-bit integer values from a connected BluetoothLE change. Service Unique ID and Characteristic Unique IDare required.
++ <a name="RegisterForShorts"></a>`RegisterForShorts` – Registers to receive updates when one or more 16-bit integer values from a connected BluetoothLE change. Service Unique ID and Characteristic Unique ID are required.
 
 ![call BluetoothLE1 RegisterForShortsservice_uuidcharacteristic_uuidsigned](blocks/BluetoothLE.RegisterForShorts.svg)
 
-+ <a name="RegisterForStrings"></a>`RegisterForStrings` – Register to receive updates when one or more string values froma connected Bluetooth device change.
++ <a name="RegisterForStrings"></a>`RegisterForStrings` – Registers to receive updates when one or more string values from a connected Bluetooth device change.
 
 ![call BluetoothLE1 RegisterForStringsserviceUuidcharacteristicUuidutf16](blocks/BluetoothLE.RegisterForStrings.svg)
 
@@ -143,23 +143,23 @@ Bluetooth Low Energy, also referred to as Bluetooth LE or simply BLE, is a new p
 
 ![call BluetoothLE1 ScanAdvertisementsscanPeriod](blocks/BluetoothLE.ScanAdvertisements.svg)
 
-+ <a name="ServiceByIndex"></a>`ServiceByIndex` – Return Unique ID of selected service with index. Index specified by list of supported services for a connected device, starting from 1.
++ <a name="ServiceByIndex"></a>`ServiceByIndex` – Returns Unique ID of selected service with index. Index specified by list of supported services for a connected device, starting from 1.
 
 ![call BluetoothLE1 ServiceByIndexindex](blocks/BluetoothLE.ServiceByIndex.svg)
 
-+ <a name="StartAdvertising"></a>`StartAdvertising` – Create and publish a Bluetooth LE advertisement. inData specifies the data that will be included in the advertisement. serviceUuid specifies the UUID of the advertisement.
++ <a name="StartAdvertising"></a>`StartAdvertising` – Creates and publishes a Bluetooth LE advertisement. inData specifies the data that will be included in the advertisement. serviceUuid specifies the UUID of the advertisement.
 
 ![call BluetoothLE1 StartAdvertisinginDataserviceUuid](blocks/BluetoothLE.StartAdvertising.svg)
 
-+ <a name="StartScanning"></a>`StartScanning` – Start Scanning for BluetoothLE devices.
++ <a name="StartScanning"></a>`StartScanning` – Starts Scanning for BluetoothLE devices.
 
 ![call BluetoothLE1 StartScanning](blocks/BluetoothLE.StartScanning.svg)
 
-+ <a name="StopAdvertising"></a>`StopAdvertising` – Stop Bluetooth LE Advertising.
++ <a name="StopAdvertising"></a>`StopAdvertising` – Stops Bluetooth LE Advertising.
 
 ![call BluetoothLE1 StopAdvertising](blocks/BluetoothLE.StopAdvertising.svg)
 
-+ <a name="StopScanning"></a>`StopScanning` – Stop Scanning for BluetoothLE devices.
++ <a name="StopScanning"></a>`StopScanning` – Stops Scanning for BluetoothLE devices.
 
 ![call BluetoothLE1 StopScanning](blocks/BluetoothLE.StopScanning.svg)
 
@@ -167,73 +167,73 @@ Bluetooth Low Energy, also referred to as Bluetooth LE or simply BLE, is a new p
 
 ![call BluetoothLE1 StopScanningAdvertisements](blocks/BluetoothLE.StopScanningAdvertisements.svg)
 
-+ <a name="SupportedCharacteristics"></a>`SupportedCharacteristics` – Return list of supported characteristics for connected device as a String
++ <a name="SupportedCharacteristics"></a>`SupportedCharacteristics` – Returns list of supported characteristics for connected device as a String
 
 ![call BluetoothLE1 SupportedCharacteristics](blocks/BluetoothLE.SupportedCharacteristics.svg)
 
-+ <a name="SupportedServices"></a>`SupportedServices` – Return list of supported services for connected device as a String
++ <a name="SupportedServices"></a>`SupportedServices` – Returns list of supported services for connected device as a String
 
 ![call BluetoothLE1 SupportedServices](blocks/BluetoothLE.SupportedServices.svg)
 
-+ <a name="UnregisterForValues"></a>`UnregisterForValues` – Unregister for updates for the given service and characteristic.
++ <a name="UnregisterForValues"></a>`UnregisterForValues` – Unregisters for updates for the given service and characteristic.
 
 ![call BluetoothLE1 UnregisterForValuesservice_uuidcharacteristic_uuid](blocks/BluetoothLE.UnregisterForValues.svg)
 
-+ <a name="WriteBytes"></a>`WriteBytes` – Write one or more 8-bit integer values to a connected BluetoothLE device. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single numeric value or a list of values. If signed is true, the acceptable values are between -128 and 127. If signed is false, the acceptable values are between 0 and 255.
++ <a name="WriteBytes"></a>`WriteBytes` – Writes one or more 8-bit integer values to a connected BluetoothLE device. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single numeric value or a list of values. If signed is true, the acceptable values are between -128 and 127. If signed is false, the acceptable values are between 0 and 255.
 
 ![call BluetoothLE1 WriteBytesserviceUuidcharacteristicUuidsignedvalues](blocks/BluetoothLE.WriteBytes.svg)
 
-+ <a name="WriteBytesWithResponse"></a>`WriteBytesWithResponse` – Write one or more 8-bit integer values to a connected BluetoothLE device and wait for an acknowledgement via the ByteValuesWritten event. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single numeric value or a list of values. If signed is true, the acceptable values are between -128 and 127. If signed is false, the acceptable values are between 0 and 255.
++ <a name="WriteBytesWithResponse"></a>`WriteBytesWithResponse` – Writes one or more 8-bit integer values to a connected BluetoothLE device and wait for an acknowledgement via the ByteValuesWritten event. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single numeric value or a list of values. If signed is true, the acceptable values are between -128 and 127. If signed is false, the acceptable values are between 0 and 255.
 
 ![call BluetoothLE1 WriteBytesWithResponseserviceUuidcharacteristicUuidsignedvalues](blocks/BluetoothLE.WriteBytesWithResponse.svg)
 
-+ <a name="WriteFloats"></a>`WriteFloats` – Write one or more floating point values to a connected BluetoothLE device. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single numeric value or a list of values. If shortFloat is true, the values will be compressed to 16-bits. If shortFloat is false, the values are sent as 32-bit.
++ <a name="WriteFloats"></a>`WriteFloats` – Writes one or more floating point values to a connected BluetoothLE device. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single numeric value or a list of values. If shortFloat is true, the values will be compressed to 16-bits. If shortFloat is false, the values are sent as 32-bit.
 
 ![call BluetoothLE1 WriteFloatsserviceUuidcharacteristicUuidshortFloatvalues](blocks/BluetoothLE.WriteFloats.svg)
 
-+ <a name="WriteFloatsWithResponse"></a>`WriteFloatsWithResponse` – Write one or more 8-bit integer values to a connected BluetoothLE device and wait for an acknowledgement via the FloatValuesWritten event. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single numeric value or a list of values. If shortFloat is true, the values will be compressed to 16-bits. If shortFloat is false, the values are sent as 32-bit.
++ <a name="WriteFloatsWithResponse"></a>`WriteFloatsWithResponse` – Writes one or more 8-bit integer values to a connected BluetoothLE device and wait for an acknowledgement via the FloatValuesWritten event. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single numeric value or a list of values. If shortFloat is true, the values will be compressed to 16-bits. If shortFloat is false, the values are sent as 32-bit.
 
 ![call BluetoothLE1 WriteFloatsWithResponseserviceUuidcharacteristicUuidshortFloatvalues](blocks/BluetoothLE.WriteFloatsWithResponse.svg)
 
-+ <a name="WriteIntegers"></a>`WriteIntegers` – Write one or more 32-bit integer values to a connected BluetoothLE device. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single numeric value or a list of values. If signed is true, the acceptable values are between -2147483648 and 2147483647. If signed is false, the acceptable values are between 0 and 4294967295.
++ <a name="WriteIntegers"></a>`WriteIntegers` – Writes one or more 32-bit integer values to a connected BluetoothLE device. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single numeric value or a list of values. If signed is true, the acceptable values are between -2147483648 and 2147483647. If signed is false, the acceptable values are between 0 and 4294967295.
 
 ![call BluetoothLE1 WriteIntegersserviceUuidcharacteristicUuidsignedvalues](blocks/BluetoothLE.WriteIntegers.svg)
 
-+ <a name="WriteIntegersWithResponse"></a>`WriteIntegersWithResponse` – Write one or more 32-bit integer values to a connected BluetoothLE device and wait for an acknowledgement via the IntegerValuesWritten event. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single numeric value or a list of values. If signed is true, the acceptable values are between -2147483648 and 2147483647. If signed is false, the acceptable values are between 0 and 4294967295.
++ <a name="WriteIntegersWithResponse"></a>`WriteIntegersWithResponse` – Writes one or more 32-bit integer values to a connected BluetoothLE device and wait for an acknowledgement via the IntegerValuesWritten event. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single numeric value or a list of values. If signed is true, the acceptable values are between -2147483648 and 2147483647. If signed is false, the acceptable values are between 0 and 4294967295.
 
 ![call BluetoothLE1 WriteIntegersWithResponseserviceUuidcharacteristicUuidsignedvalues](blocks/BluetoothLE.WriteIntegersWithResponse.svg)
 
-+ <a name="WriteShorts"></a>`WriteShorts` – Write one or more 16-bit integer values to a connected BluetoothLE device. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single numeric value or a list of values. If signed is true, the acceptable values are between -32768 and 32767. If signed is false, the acceptable values are between 0 and 65535.
++ <a name="WriteShorts"></a>`WriteShorts` – Writes one or more 16-bit integer values to a connected BluetoothLE device. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single numeric value or a list of values. If signed is true, the acceptable values are between -32768 and 32767. If signed is false, the acceptable values are between 0 and 65535.
 
 ![call BluetoothLE1 WriteShortsserviceUuidcharacteristicUuidsignedvalues](blocks/BluetoothLE.WriteShorts.svg)
 
-+ <a name="WriteShortsWithResponse"></a>`WriteShortsWithResponse` – Write one or more 16-bit integer values to a connected BluetoothLE device and wait for an acknowledgement via the ShortValuesWritten event.Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single numeric value or a list of values. If signed is true, the acceptable values are between -32768 and 32767. If signed is false, the acceptable values are between 0 and 65535.
++ <a name="WriteShortsWithResponse"></a>`WriteShortsWithResponse` – Writes one or more 16-bit integer values to a connected BluetoothLE device and wait for an acknowledgement via the ShortValuesWritten event. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single numeric value or a list of values. If signed is true, the acceptable values are between -32768 and 32767. If signed is false, the acceptable values are between 0 and 65535.
 
 ![call BluetoothLE1 WriteShortsWithResponseserviceUuidcharacteristicUuidsignedvalues](blocks/BluetoothLE.WriteShortsWithResponse.svg)
 
-+ <a name="WriteStrings"></a>`WriteStrings` – Write one or more strings to a connected BluetoothLE device. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single string or a list of strings. If utf16 is true, the strings are sent UTF-16 encoded. If utf16 is false, the strings are sent UTF-8 encoded.
++ <a name="WriteStrings"></a>`WriteStrings` – Writes one or more strings to a connected BluetoothLE device. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single string or a list of strings. If utf16 is true, the strings are sent UTF-16 encoded. If utf16 is false, the strings are sent UTF-8 encoded.
 
 ![call BluetoothLE1 WriteStringsserviceUuidcharacteristicUuidutf16values](blocks/BluetoothLE.WriteStrings.svg)
 
-+ <a name="WriteStringsWithResponse"></a>`WriteStringsWithResponse` – Write one or more strings to a connected BluetoothLE device and wait for an acknowledgement. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single string or a list of values. If utf16 is true, the strings are sent UTF-16 encoded. If utf16 is false, the strings are sent UTF-8 encoded.
++ <a name="WriteStringsWithResponse"></a>`WriteStringsWithResponse` – Writes one or more strings to a connected BluetoothLE device and wait for an acknowledgement. Service Unique ID and Characteristic Unique ID are required. The values parameter can either be a single string or a list of values. If utf16 is true, the strings are sent UTF-16 encoded. If utf16 is false, the strings are sent UTF-8 encoded.
 
 ![call BluetoothLE1 WriteStringsWithResponseserviceUuidcharacteristicUuidutf16values](blocks/BluetoothLE.WriteStringsWithResponse.svg)
 
 ## Events
 
-+ <a name="BytesReceived"></a>`BytesReceived` – Trigger event when one or more byte values from a connected BluetoothLE device are received.
++ <a name="BytesReceived"></a>`BytesReceived` – Triggers event when one or more byte values from a connected BluetoothLE device are received.
 
 ![when BluetoothLE1 BytesReceived serviceUuid characteristicUuid byteValues do](blocks/BluetoothLE.BytesReceived.svg)
 
-+ <a name="BytesWritten"></a>`BytesWritten` – Event for BytesWritten
++ <a name="BytesWritten"></a>`BytesWritten` – Triggers event when one or more byte values are sent to a connected BluetoothLE.
 
 ![when BluetoothLE1 BytesWritten serviceUuid characteristicUuid byteValues do](blocks/BluetoothLE.BytesWritten.svg)
 
-+ <a name="Connected"></a>`Connected` – Trigger event when a BluetoothLE device is connected.
++ <a name="Connected"></a>`Connected` – Triggers event when a BluetoothLE device is connected.
 
 ![when BluetoothLE1 Connecteddo](blocks/BluetoothLE.Connected.svg)
 
-+ <a name="DeviceFound"></a>`DeviceFound` – Trigger event when a new BluetoothLE device is found.
++ <a name="DeviceFound"></a>`DeviceFound` – Triggers event when a new BluetoothLE device is found.
 
 ![when BluetoothLE1 DeviceFounddo](blocks/BluetoothLE.DeviceFound.svg)
 
@@ -241,7 +241,7 @@ Bluetooth Low Energy, also referred to as Bluetooth LE or simply BLE, is a new p
 
 ![when BluetoothLE1 Disconnecteddo](blocks/BluetoothLE.Disconnected.svg)
 
-+ <a name="FloatsReceived"></a>`FloatsReceived` – Trigger event when one or more floating point values from a BluetoothLE device are received.
++ <a name="FloatsReceived"></a>`FloatsReceived` – Triggers event when one or more floating point values from a BluetoothLE device are received.
 
 ![when BluetoothLE1 FloatsReceived serviceUuid characteristicUuid floatValues do](blocks/BluetoothLE.FloatsReceived.svg)
 
@@ -249,7 +249,7 @@ Bluetooth Low Energy, also referred to as Bluetooth LE or simply BLE, is a new p
 
 ![when BluetoothLE1 FloatsWritten serviceUuid characteristicUuid floatValues do](blocks/BluetoothLE.FloatsWritten.svg)
 
-+ <a name="IntegersReceived"></a>`IntegersReceived` – Trigger event when one or more integer values from a connected BluetoothLE device are received.
++ <a name="IntegersReceived"></a>`IntegersReceived` – Triggers event when one or more integer values from a connected BluetoothLE device are received.
 
 ![when BluetoothLE1 IntegersReceived serviceUuid characteristicUuid intValues do](blocks/BluetoothLE.IntegersReceived.svg)
 
@@ -257,11 +257,11 @@ Bluetooth Low Energy, also referred to as Bluetooth LE or simply BLE, is a new p
 
 ![when BluetoothLE1 IntegersWritten serviceUuid characteristicUuid intValues do](blocks/BluetoothLE.IntegersWritten.svg)
 
-+ <a name="RssiChanged"></a>`RssiChanged` – Trigger event when RSSI (Received Signal Strength Indicator) of found BluetoothLE device changes
++ <a name="RssiChanged"></a>`RssiChanged` – Triggers event when RSSI (Received Signal Strength Indicator) of found BluetoothLE device changes
 
 ![when BluetoothLE1 RssiChanged device_rssi do](blocks/BluetoothLE.RssiChanged.svg)
 
-+ <a name="ShortsReceived"></a>`ShortsReceived` – Trigger event when one or more short values from a connected BluetoothLE device are received.
++ <a name="ShortsReceived"></a>`ShortsReceived` – Triggers event when one or more short values from a connected BluetoothLE device are received.
 
 ![when BluetoothLE1 ShortsReceived serviceUuid characteristicUuid shortValues do](blocks/BluetoothLE.ShortsReceived.svg)
 
@@ -269,12 +269,10 @@ Bluetooth Low Energy, also referred to as Bluetooth LE or simply BLE, is a new p
 
 ![when BluetoothLE1 ShortsWritten serviceUuid characteristicUuid shortValues do](blocks/BluetoothLE.ShortsWritten.svg)
 
-+ <a name="StringsReceived"></a>`StringsReceived` – Trigger event when one or more string values from a connected BluetoothLE device a received.
++ <a name="StringsReceived"></a>`StringsReceived` – Triggers event when one or more string values from a connected BluetoothLE device a received.
 
 ![when BluetoothLE1 StringsReceived serviceUuid characteristicUuid stringValues do](blocks/BluetoothLE.StringsReceived.svg)
 
 + <a name="StringsWritten"></a>`StringsWritten` – Event for StringsWritten
 
 ![when BluetoothLE1 StringsWritten serviceUuid characteristicUuid stringValues do](blocks/BluetoothLE.StringsWritten.svg)
-
-

--- a/docs/src/app/pages/DevicesIntro.md
+++ b/docs/src/app/pages/DevicesIntro.md
@@ -3,12 +3,12 @@ To connect with the world of IoT you need an IoT device. An IoT device allows yo
 
 Currently, App Inventor supports the [Arduino 101](#/arduino101/arduino101intro) and [BBC micro:bit](#/microbit/microbitintro) devices.
 
-Before building your IoT creations you need to set up your environment. See [Getting Started](#/getstarted/intro) for instructions.
+Before building for IoT, you need to set up your environment. See [Getting Started](#/getstarted/intro) for instructions.
 
-Next, we need to learn how to build an App Inventor app that can connect to our Arduino. At present, we use Bluetooth to connect to our IoT Devices (we are working on WiFi). Building a basic app that can connect via bluetooth is easy. You can find [tutorials here](#/teachers/tutorials).
+Next, you need to learn how to build an App Inventor app that can connect to our Arduino. At present, we use Bluetooth to connect to our IoT Devices (Wifi connection coming soon). Building basic apps that connect via Bluetooth is easy. You can find [tutorials here](#/teachers/tutorials).
 
 # Documentation
-These pages contain all the detailed documentation on how to use these devices with App Inventor. These pages will help you discover all the features available, and how to use them.
+These pages contain detailed documentation on how to use these devices with App Inventor. These pages will help you discover available features, and how to use them.
 
 *   [Bluetooth low energy](#/bluetoothle/bluetoothleintro)
 *   [Arduino 101](#/arduino101/arduino101intro)

--- a/docs/src/app/pages/GetStartedIntro.md
+++ b/docs/src/app/pages/GetStartedIntro.md
@@ -1,10 +1,8 @@
 ## Getting Started with MIT App Inventor IoT
 
 You may already know how to build mobile apps with
-MIT App Inventor, but if you are new to this way of building apps we
-suggest you
-<a href="http://appinventor.mit.edu/explore/ai2/tutorials.html" target="_blank">become familiar</a>
-with some basic functions in MIT App Inventor.
+MIT App Inventor, but if you are new to this system, please
+<a href="http://appinventor.mit.edu/explore/ai2/tutorials.html" target="_blank">click here</a> to become familiar with some basic functions in MIT App Inventor.
 
 <b>Hardware</b><br>
 To build Internet of Things (IoT) apps with MIT App Inventor, you will be working with external
@@ -22,7 +20,7 @@ to work with the Arduino 101 device controller. You will then need to
 <a href="/assets/tutorials/MIT_App_Inventor_Basic_Connection.pdf" target="_blank">connect to the Arduino 101</a> using MIT App Inventor.
 
 <b>Start with a simple IoT app (~ 30 minutes)</b><br>
-Before you begin with a full tutorial or a How To exercise, you may want to start with a simple app to turn an LED light 
+Before you begin with a full tutorial or a How To exercise, you may want to start with a simple app to turn an LED light
 on and off. This <a href="/assets/tutorials/MIT_App_Inventor_IoT_Starter_Tutorial.pdf" target="_blank">Starter Tutorial</a> will take about 30 minutes.
 
 <b>Then try a How To sensor app</b><br>

--- a/docs/src/app/pages/HelpIntro.md
+++ b/docs/src/app/pages/HelpIntro.md
@@ -3,7 +3,7 @@
 Now that you're up and running you're ready to start building Apps! We suggest starting with the
 <a href="/assets/howtos/MIT_App_Inventor_IoT_Light_Sensor.pdf" target="_blank">Light Sensor</a>
 and <a href="/assets/resources/MIT_App_Inventor_IoT_RgbLcd.pdf" target="_blank">RGB LCD Display</a>
-tutorials, then exploring on your own! We have a number of resources to help you build IoT apps with MIT App Inventor.
+tutorials, then exploring on your own! We also have resources available to help you with building your IoT apps with MIT App Inventor.
 
 ## [IoT Devices](#/devices/devicesintro)
 View the documentation for the supported [IoT Devices](#/devices/devicesintro).

--- a/docs/src/app/pages/HelpIntro.md
+++ b/docs/src/app/pages/HelpIntro.md
@@ -1,12 +1,9 @@
 # Help
-Find all the help you need to get started in teaching, learning and using IoT with MIT App Inventor.
-
-__Next steps:__
 
 Now that you're up and running you're ready to start building Apps! We suggest starting with the
 <a href="/assets/howtos/MIT_App_Inventor_IoT_Light_Sensor.pdf" target="_blank">Light Sensor</a>
 and <a href="/assets/resources/MIT_App_Inventor_IoT_RgbLcd.pdf" target="_blank">RGB LCD Display</a>
-tutorials, then exploring on your own! We also have resources available to help you with building your IoT apps with MIT App Inventor.
+tutorials, then exploring on your own! We have a number of resources to help you build IoT apps with MIT App Inventor.
 
 ## [IoT Devices](#/devices/devicesintro)
 View the documentation for the supported [IoT Devices](#/devices/devicesintro).

--- a/docs/src/app/pages/MakerIntro.md
+++ b/docs/src/app/pages/MakerIntro.md
@@ -3,10 +3,7 @@
 # Welcome, Makers!
 
 The maker movement has drawn enormous vitality over the past decade
-from two computing breakthroughs.  One is mobile
-computing: we now carry around with us computers of tremendous power
-that can link over the Internet to vast resources of data and computation.
-The other is the Internet of Things (IoT), which brings an entire
+from two computing breakthroughs. One is mobile computing: we now carry with us computers of tremendous power that link to vast resources of data and computation. The other is the Internet of Things (IoT), which brings an entire
 realm of physical objects within the scope of digital sensing and
 control.
 

--- a/docs/src/app/pages/StudentExamples.md
+++ b/docs/src/app/pages/StudentExamples.md
@@ -5,11 +5,10 @@
 
 **Description:** The home lighting automation system allows a young people who is confined to bed rest to turn on and off the lights in the room, so they don’t have to ask their parents or friends for help. The MIT App Inventor IoT app allows the person to communicate with the lights using Arduino with Bluetooth and a relay.
 
-**Benefit:** This app gives the youth empowerment over their environment, while in a condition that would otherwise force them to rely on others. Developing this app helped these two young innovators understand the impact that their creations can have on the lives of others.
+**Benefit:** This app gives individuals self-reliance and control over their environment. Developing this app helped these two young innovators understand the impact that their creations can have on the lives of others.
 
 **Location:** Pakistan
 
 **Developers age:** 12
 
 [![Internet of Things Session at LearnOBots](http://img.youtube.com/vi/9DKTp1LscMg/0.jpg)](http://www.youtube.com/watch?v=9DKTp1LscMg "Internet of Things Session at LearnOBots")
-

--- a/docs/src/app/pages/StudentIntro.md
+++ b/docs/src/app/pages/StudentIntro.md
@@ -3,16 +3,11 @@
 # Welcome, Students!
 
 You might know that MIT App Inventor lets you create exciting apps for
-smartphones and tablets with your friends and classmates. Now, with
-the Internet of Things extension to App Inventor (MIT App Inventor
-IoT) your apps can connect to physical and digital
-objects all around you!
+smartphones and tablets with your friends and classmates. Now, with the Internet of Things extension to App Inventor (MIT App Inventor IoT), your apps can connect to physical and digital objects all around you!
 
 You can build apps that control lights, buttons, buzzers, motors,
 robots, electrical appliances and a growing universe of connected
-devices.  You can use sensors to capture a wealth of data, including temperature, sound, light, color, moisture, motion, touch, heart rate, and many more, with support for new sensors appearing daily.  You can combine controls
-and sensors with all the other features of your App Inventor apps like
-speech recognition, databases and communication.
+devices. You can use sensors to capture a wealth of data, including temperature, sound, light, color, moisture, motion, touch, heart rate, and much more, with support for new sensors appearing daily. You can combine controls and sensors with all the other features of your App Inventor apps, like speech recognition, databases, and communication.
 
 To build IoT apps you'll need an <em>IoT device controller</em>, which
 connects to the various devices and manages the communication with your

--- a/docs/src/app/pages/TeacherExamples.md
+++ b/docs/src/app/pages/TeacherExamples.md
@@ -5,7 +5,7 @@
 
 **App Name:** Home Lighting Automation System
 
-**Description:** Turn the lights on and off without leaving your bed with a home lighting automation system. This allows individuals who are confined to bed rest to change the lighting independently without needing to request caregiver assistance.
+**Description:** Turn the lights on and off without leaving your bed with a home lighting automation system. This allows individuals who are confined to bed rest to change the lighting independently, without caregiver assistance.
 
 **Benefit:** This app gives an individual more power over their environment, rather than having to rely on others. Developing this app helped these two young innovators measurably improve the lives of others.
 

--- a/docs/src/app/pages/TeacherIntro.md
+++ b/docs/src/app/pages/TeacherIntro.md
@@ -4,13 +4,13 @@
 
 The Internet of Things (IoT) is poised to transform modern living&mdash; with estimates of more than 20 billion connected devices worldwide by 2020.
 
-You may already know that MIT App Inventor lets you help your students create original mobile apps that can make real-world differences to themselves and their communities.
+You may already know that MIT App Inventor helps your students create original mobile apps that can make real-world differences for themselves and their communities.
 
-Now, with MIT App Inventor IoT, your students can build apps that communicate with physical and digital objects all around them. App Inventor IoT extends the reach of mobile apps to sensors, actuators, robots and to an expanding universe of connected devices.
+Now, with MIT App Inventor IoT, your students can build apps that communicate with physical and digital objects all around them. App Inventor IoT extends the reach of mobile apps to sensors, actuators, robots, and an expanding universe of connected devices.
 
-The biggest difference between ordinary MIT App Inventor apps and MIT App Inventor IoT apps is that IoT apps communicate with external devices through <em>IoT devices controllers</em>. One of the most common controllers for IoT development is the Arduino, but there are other controllers on the market.
+The biggest difference between ordinary MIT App Inventor apps and MIT App Inventor IoT apps is that IoT apps communicate with external devices using <em>IoT devices controllers</em>. One of the most common controllers for IoT development is the Arduino, but there are other controllers on the market.
 
-Your students can build apps with all kinds of sensors (like sensors for temperature, moisture, noise, light, color, or motion) and other devices (like buttons and switches and relays) connected to a controller. Using App Inventor, they can program controllers to trigger connected devices to activate sensors, turn on lights, play sounds, move motors, and more! Students can even control the devices from their smartphones!
+Your students can build apps with all kinds of sensors (like sensors for temperature, moisture, noise, light, color, or motion) and other devices (like buttons, switches, and relays) connected to a controller. Using App Inventor, they can program controllers to trigger connected devices to activate sensors, turn on lights, play sounds, move motors, and more! Students can even control the devices from their smartphones!
 
 This first release of MIT App Inventor IoT supports the Arduino 101 and the BBC micro:bit controllers, with support for more controllers coming soon.
 


### PR DESCRIPTION
Implements the vast majority of #109 

- Most of the changes were to API descriptions for the BluetoothLE module. Are these autogenerated? If so, where should they be changed? @ewpatton 

- One change was already handled.

- Two questions left unanswered from Hedge's notes:

- [ ] http://iot.appinventor.mit.edu/#/arduino101/arduino101intro	
The Arduino 101 is a version of the popular Arduino platform based on the Intel® Curie™ chipset. It has the same form factor as many other Arduino but supports built-in Bluetooth® low energy.	What if I don't know what an Arduino is or what it does?

- [ ] http://iot.appinventor.mit.edu/#/bluetoothle/bluetoothleintro	
Bluetooth Low Energy, also referred to as Bluetooth LE or simply BLE, is a new protocol similar to classic Bluetooth except that it is designed to consume less power while maintaining comparable functionality. 	
What if I don't know what a Bluetooth is?  Can we refer to it as a connection protocol or something?

@hnichols9560