### PR TITLE
Make the App Inventor icon responsive to small screen sizes

### DIFF
--- a/docs/src/app/Master.js
+++ b/docs/src/app/Master.js
@@ -15,6 +15,8 @@ import ForStudentsMenu from './ForStudentsMenu';
 import ForMakersMenu from './ForMakersMenu';
 import DocumentationMenu from './DocumentationMenu';
 
+require('./icon.css');
+
 class Master extends Component {
   static propTypes = {
     children: PropTypes.node,
@@ -215,7 +217,7 @@ class Master extends Component {
           }
           iconElementRight={
             <a href="http://appinventor.mit.edu" style={prepareStyles(styles.browserstackLogo)} target="_blank">
-              <img src="images/logo-white.png" width="auto" />
+              <span className="aim-icon" />
             </a>
           }
           style={

--- a/docs/src/app/icon.css
+++ b/docs/src/app/icon.css
@@ -1,0 +1,13 @@
+span.aim-icon {
+  background-image: url(/images/logo-white.png);
+  width: 225px;
+  height: 48px;
+  display: inline-block;
+}
+
+@media(max-width: 1024px) {
+  span.aim-icon {
+      width: 48px;
+      margin-right: 6px;
+  }
+}


### PR DESCRIPTION
This PR add some CSS media rules for the MIT App Inventor logo in the top right so that shrinks to just the icon on smaller screens.