### PR TITLE
Fix homepage buttons and visuals

### DIFF
--- a/docs/src/app/Home.js
+++ b/docs/src/app/Home.js
@@ -11,6 +11,8 @@ import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme';
 import {darkWhite, white} from 'material-ui/styles/colors';
 import RaisedButton from 'material-ui/RaisedButton';
 
+require('./main.css');
+
 class HomePage extends Component {
 
   static propTypes = {
@@ -91,7 +93,7 @@ class HomePage extends Component {
     return (
       <FullWidthSection style={styles.root}>
         <div style={styles.tagline}>
-          <h2 style={styles.h1}>MIT App Inventor - Internet&nbsp;of&nbsp;Things</h2>
+          <h2 style={styles.h1}>MIT App Inventor + Internet&nbsp;of&nbsp;Things</h2>
         </div>
       </FullWidthSection>
     );
@@ -122,15 +124,13 @@ class HomePage extends Component {
       buttonHolder: {
         flexGrow: 0,
         padding: 1,
+        margin: '0 auto'
       },
       buttonHolderCenter: {
         display: 'flex',
         flexGrow: 1,
         padding: 1,
         justifyContent: 'center',
-      },
-      button200: {
-        width: 200,
       },
       buttonCenter: {
         alignSelf: 'center',
@@ -157,10 +157,10 @@ class HomePage extends Component {
         MIT App Inventor now brings that same power and simplicity of app creation to the Internet of Things (IoT) and
         the universe of connected devices.
         <br /><br /><br />
-        <div style={styles.buttonCluster}>
+        <div className="button-holder" style={styles.buttonCluster}>
           <span style={styles.buttonHolder}>
             <RaisedButton
-              style={styles.button200}
+              className="button200"
               label="Learn more about IoT" href="#LearnMore"
               primary={true}
             />
@@ -174,7 +174,7 @@ class HomePage extends Component {
           </span>
           <span style={styles.buttonHolder}>
             <RaisedButton
-              style={styles.button200}
+              className="button200"
               label="Create Apps!"
               href="http://ai2.appinventor.mit.edu" target="_blank"
               primary={true}

--- a/docs/src/app/HomeFeature.js
+++ b/docs/src/app/HomeFeature.js
@@ -46,6 +46,7 @@ class HomeFeature extends Component {
       image: {
         // Not sure why this is needed but it fixes a display issue in chrome
         marginBottom: -6,
+        width: '100%'
       },
       heading: {
         fontSize: 20,

--- a/docs/src/app/Master.js
+++ b/docs/src/app/Master.js
@@ -44,7 +44,12 @@ class Master extends Component {
 
   componentWillMount() {
     this.setState({
-      muiTheme: getMuiTheme(),
+        muiTheme: getMuiTheme({
+            palette: {
+                primary1Color: '#a5cf47',
+                accent1Color: '#00728a',
+            }
+        }),
     });
   }
 

--- a/docs/src/app/main.css
+++ b/docs/src/app/main.css
@@ -1,0 +1,31 @@
+/* -*- mode: css; css-indent-offset: 2; -*- */
+.primary {
+  background-color: rgb(102, 187, 106);
+}
+
+.secondary {
+  background-color: rgb(0, 114, 138);
+}
+
+.button-holder {
+  width: 100%;
+}
+
+@media(min-width: 750px) {
+  .button-holder>.button200 {
+    width: 200px;
+  }
+}
+
+@media(max-width: 749px) {
+  .button-holder {
+    max-width: 360px;
+    margin: 0 auto;
+  }
+  .button-holder>span, .button-holder>span>div {
+    width: 100%;
+  }
+  .button-holder>span>div {
+    margin-bottom: 6pt;
+  }
+}


### PR DESCRIPTION
This commit changes the CSS for the buttons and images to fix the
following:

- Button color matches the primary theme green
- Buttons center on smaller device screens
- Images do not overflow the "For ..." header

Fixes #147
